### PR TITLE
addon_*_bsd.cfg: don't try to modify if file doesn't exist

### DIFF
--- a/templates/grub-pxelinux_config
+++ b/templates/grub-pxelinux_config
@@ -107,7 +107,9 @@ if [ -d "$MOUNT_POINT_"/boot/release ] ; then
 fi
 
 # adjust ldbsd.com bootline
-sed -i -e 's#\(.*kernel .*/ldbsd.com\)#\1 set image /boot/addons/bsd4grml/bsd.rd`echo Type "boot" to load MirOS bsd4grml via keeppxe#' "$TFTPD_DATA_DIR_/"addon_*_bsd.cfg
+if ls "$TFTPD_DATA_DIR_/"addon_*_bsd.cfg >/dev/null 2>&1; then
+  sed -i -e 's#\(.*kernel .*/ldbsd.com\)#\1 set image /boot/addons/bsd4grml/bsd.rd`echo Type "boot" to load MirOS bsd4grml via keeppxe#' "$TFTPD_DATA_DIR_/"addon_*_bsd.cfg
+fi
 
 # remove grub entries
 rm -f "$TFTPD_DATA_DIR_/"addon_*grub*.cfg


### PR DESCRIPTION
This exhibits an ugly error message if no such file exists,
so let's check if any such file exists before trying to
operate on them

/cc @jkirk 