### PR TITLE
nfs-kernel-server: no longer check for nfs version 3 with UDP

### DIFF
--- a/nfs-kernel-server
+++ b/nfs-kernel-server
@@ -89,17 +89,6 @@ case "$1" in
 		    }
 		fi
 
-		if [ -x $PREFIX/bin/rpcinfo ] ; then
-			RPCINFO=$PREFIX/bin/rpcinfo
-		elif [ -x $PREFIX/sbin/rpcinfo ] ; then
-			RPCINFO=$PREFIX/sbin/rpcinfo
-		else
-			echo "Error: could not locate rpcinfo binary." >&2
-			exit 1
-		fi
-		$RPCINFO -u localhost nfs 3 >/dev/null 2>&1 ||
-		    RPCMOUNTDOPTS="$RPCMOUNTDOPTS --no-nfs-version 3"
-
 		[ -z "$ClearAddr" ] || echo "nfsd 127.0.0.1 1" >/proc/net/rpc/auth.unix.ip/channel
 
 		start-stop-daemon --start --quiet \


### PR DESCRIPTION
Quoting from https://salsa.debian.org/kernel-team/nfs-utils:

```
| commit fbd7623dd8d5e418e7cb369d4026d5368f7c46a6
| Author: Jeff Layton <jlayton@redhat.com>
| Date:   Wed Apr 5 13:26:49 2017 -0400
|
|     nfsd: don't enable a UDP socket by default
|
|     Most major NFS clients have supported TCP for at least a decade now,
|     and v4-only shops are becoming more prevalent. It seems reasonable that
|     serving over UDP should be something that is "opt-in".
|
|     I've always hesitated to do this in the past, but now that we have
|     nfs.conf, it seems like the time may be right to disable UDP in default
|     configurations. In particular, it would be good to try this in the more
|     bleeding edge distros (Fedora, Ubuntu, SuSE, etc...) and see how
|     problematic it is.
|
|     Change the default in rpc.nfsd to just open TCP ports by default. Add
|     new -u and -t options that allow users to explicitly override what's
|     in the config file, and update the usage message and manpage.
```
So nowadays the `rpcinfo -u localhost nfs 3` fails, and we end up with a NFS server having NFS v3 disabled.

While we could switch to `rpcinfo -t localhost nfs 3` instead, there's probably no need to check for this any longer, as NFS v3 should be common enough (verified with grml64-full 2021.07 + grml64-full 2022.11-rc1).

Thanks: András Korn
Closes: https://github.com/grml/grml-terminalserver/issues/8