### PR TITLE
Avoid full path usage for invocation of ip(8)

### DIFF
--- a/grml-terminalserver-config
+++ b/grml-terminalserver-config
@@ -194,7 +194,7 @@ for addresses from 192.168.0.101 to (and including) 192.168.0.200.
 
   NAMESERVERS_=`netGetNameservers warn`
   GW_=`netGetDefaultGateway warn`
-  GW_DEV_=`/sbin/ip route get "$GW_" | sed 's/^local //' | awk '{ print $3; exit; }'`
+  GW_DEV_=`ip route get "$GW_" | sed 's/^local //' | awk '{ print $3; exit; }'`
   if [ "$GW_DEV_" != "$INTERFACE_" ] && [ "$GW_DEV_" != "" ] && [ "$GW_DEV_" != "lo" ]; then
     # GW_DEV_ of server is not the same device as the one serviced by dhcpd
     # so it doesn't make sense to provide the GW_ address to the clients


### PR DESCRIPTION
iproute2 used to ship a symlink from /sbin/ip to /bin/ip for backwards compatibility, though this got recently dropped (see https://lists.debian.org/debian-devel/2024/08/msg00208.html).

While this got restored again afterwards, let's be prepared!