### PR TITLE
grml-terminalserver-config: properly cleanup temporary file

### DIFF
--- a/grml-terminalserver-config
+++ b/grml-terminalserver-config
@@ -281,7 +281,7 @@ checkRoot die 'You have to be root to use this program'
 execute "mkdir -p $PATH_" die
 
 TMP_=`mktemp -t grml-terminalserver-config.XXXXXX` || die "Could not create tmpfile" $?
-setExitFunction 'removeTmpFiles'
+trap removeTmpFiles EXIT
 
 
 . $DEFAULT_CONFIG_


### PR DESCRIPTION
In commit 15a5bb7f5f9fb8ec23ad5f1dab32820a0451c9a2 the setExitFunction function got removed, but grml-terminalserver-config still relied on it.

Replace it with bash's built-in trap command to be called when the script exists, regardless of how it exits.

Fixes:

```
/usr/sbin/grml-terminalserver-config: line 284: setExitFunction: command not found
```